### PR TITLE
bug: Fix release pipeline on arm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERIO_USERNAME }}
-          password: ${{ secrets.DOCKERIO_TOKEN }}          
+          password: ${{ secrets.DOCKERIO_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
@@ -28,10 +32,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERIO_USERNAME }}
           password: ${{ secrets.DOCKERIO_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,11 @@ jobs:
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERIO_USERNAME }}
-          password: ${{ secrets.DOCKERIO_TOKEN }}
+          password: ${{ secrets.DOCKERIO_TOKEN }}          
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:


### PR DESCRIPTION
Signed-off-by: Jinjing.Zhou <allenzhou@tensorchord.ai>

Need to setup docker-container driver and qemu beforehand 
Fix #56 

Reference: https://docs.docker.com/build/building/multi-platform/
> When the current builder instance is backed by the docker-container driver, you can specify multiple platforms together. In this case, it builds a manifest list which contains images for all specified architectures. When you use this image in [docker run](https://docs.docker.com/engine/reference/commandline/run/) or [docker service](https://docs.docker.com/engine/reference/commandline/service/), Docker picks the correct image based on the node’s platform.
> 
> You can build multi-platform images using three different strategies that are supported by Buildx and Dockerfiles:
> 
> Using the QEMU emulation support in the kernel
> Building on multiple native nodes using the same builder instance
> Using a stage in Dockerfile to cross-compile to different architectures