### PR TITLE
refactor: Make kubernetes in runtime

### DIFF
--- a/api/types/environment.go
+++ b/api/types/environment.go
@@ -26,10 +26,29 @@ type ObjectMeta struct {
 type EnvironmentSpec struct {
 	Owner string            `json:"owner,omitempty"`
 	Image string            `json:"image,omitempty"`
-	Env   []string          `json:"env,omitempty"`
+	Env   []EnvVar          `json:"env,omitempty"`
 	Cmd   []string          `json:"cmd,omitempty"`
 	Ports []EnvironmentPort `json:"ports,omitempty"`
 	// TODO(gaocegege): Add volume specific spec.
+}
+
+type EnvVar struct {
+	// Name of the environment variable. Must be a C_IDENTIFIER.
+	Name string `json:"name"`
+
+	// Optional: no more than one of the following may be specified.
+
+	// Variable references $(VAR_NAME) are expanded
+	// using the previously defined environment variables in the container and
+	// any service environment variables. If a variable cannot be resolved,
+	// the reference in the input string will be unchanged. Double $$ are reduced
+	// to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+	// "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+	// Escaped references will never be expanded, regardless of whether the variable
+	// exists or not.
+	// Defaults to "".
+	// +optional
+	Value string `json:"value,omitempty"`
 }
 
 type EnvironmentStatus struct {

--- a/client/client.go
+++ b/client/client.go
@@ -11,8 +11,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/cockroachdb/errors"
 	"github.com/docker/go-connections/sockets"
-	"github.com/pkg/errors"
 )
 
 // Refer to github.com/docker/docker/client

--- a/client/errors.go
+++ b/client/errors.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 
 	"github.com/tensorchord/envd-server/errdefs"
 )

--- a/client/options.go
+++ b/client/options.go
@@ -12,9 +12,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
-	"github.com/pkg/errors"
 )
 
 // Opt is a configuration option to initialize a client

--- a/client/request.go
+++ b/client/request.go
@@ -16,9 +16,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/cockroachdb/errors"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 )
 
 // serverResponse is a wrapper for http API responses.

--- a/pkg/docs/docs.go
+++ b/pkg/docs/docs.go
@@ -659,6 +659,19 @@ const docTemplate = `{
                 }
             }
         },
+        "types.EnvVar": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                },
+                "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".\n+optional",
+                    "type": "string"
+                }
+            }
+        },
         "types.Environment": {
             "type": "object",
             "properties": {
@@ -780,7 +793,7 @@ const docTemplate = `{
                 "env": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/types.EnvVar"
                     }
                 },
                 "image": {

--- a/pkg/runtime/kubernetes/const.go
+++ b/pkg/runtime/kubernetes/const.go
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package kubernetes
+
+const (
+	ResourceNvidiaGPU = "nvidia/gpu"
+)

--- a/pkg/runtime/kubernetes/environment_create.go
+++ b/pkg/runtime/kubernetes/environment_create.go
@@ -1,0 +1,195 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/errors"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tensorchord/envd-server/api/types"
+	servertypes "github.com/tensorchord/envd-server/api/types"
+	"github.com/tensorchord/envd-server/pkg/consts"
+	"github.com/tensorchord/envd-server/pkg/util/imageutil"
+)
+
+func (p generalProvisioner) EnvironmentCreate(ctx context.Context,
+	owner string, env servertypes.Environment,
+	meta types.ImageMeta) (*servertypes.Environment, error) {
+	resRequest, err := extractResourceRequest(env)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to extract resource request")
+	}
+
+	labels := map[string]string{
+		consts.PodLabelUID:             owner,
+		consts.PodLabelEnvironmentName: env.Name,
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"login-name":   owner,
+		"image_labels": meta.Labels,
+		"environment":  env,
+	}).Debug("prepare to create the environment")
+	annotations := map[string]string{}
+	for k, v := range meta.Labels {
+		annotations[k] = v
+	}
+
+	repoLabel, ok := meta.Labels[consts.ImageLabelRepo]
+	repoInfo := &types.EnvironmentRepoInfo{}
+	if ok {
+		repoInfo, err = imageutil.RepoInfoFromLabel(repoLabel)
+		if err != nil {
+			logrus.Info("failed to parse repo from label")
+			return nil, errors.Wrap(err, "failed to parse repo from label")
+		}
+	}
+
+	projectName, ok := meta.Labels[consts.ImageLabelContainerName]
+	if !ok {
+		logrus.Info("failed to get the project name from label")
+		return nil, errors.Wrap(err, "failed to get the project name from label")
+	}
+	logrus.WithFields(logrus.Fields{
+		"repo":    repoInfo,
+		"project": projectName,
+	}).Debug("creating environment")
+	hostKeyPath := "/var/envd/hostkey"
+	authKeyPath := "/var/envd/authkey"
+	var defaultPermMode int32 = 0666
+	expectedPod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        env.Name,
+			Namespace:   p.namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "envd",
+					Image: env.Spec.Image,
+					Ports: []v1.ContainerPort{
+						{
+							Name:          "ssh",
+							ContainerPort: 2222,
+						},
+					},
+					Env: []v1.EnvVar{
+						{
+							Name:  "ENVD_HOST_KEY",
+							Value: hostKeyPath,
+						},
+						{
+							Name:  "ENVD_AUTHORIZED_KEYS_PATH",
+							Value: authKeyPath,
+						},
+						{
+							Name:  "ENVD_WORKDIR",
+							Value: fmt.Sprintf("/home/envd/%s", projectName),
+						},
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "secret",
+							ReadOnly:  true,
+							MountPath: hostKeyPath,
+							SubPath:   "hostkey",
+						},
+						{
+							Name:      "secret",
+							ReadOnly:  true,
+							MountPath: authKeyPath,
+							SubPath:   "publickey",
+						},
+					},
+					Resources: v1.ResourceRequirements{
+						Requests: resRequest,
+						Limits:   resRequest,
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "secret",
+					VolumeSource: v1.VolumeSource{
+						Secret: &v1.SecretVolumeSource{
+							SecretName:  "envd-server",
+							DefaultMode: &defaultPermMode,
+						},
+					},
+				},
+			},
+		},
+	}
+	if repoInfo != nil && len(repoInfo.URL) > 0 {
+		logrus.Debugf("clone code from %s", repoInfo.URL)
+		expectedPod.Spec.InitContainers = append(expectedPod.Spec.InitContainers, v1.Container{
+			Name:  "git-cloner",
+			Image: "alpine/git",
+			Args:  []string{"clone", "--", repoInfo.URL, "/code"},
+			VolumeMounts: []v1.VolumeMount{
+				{
+					Name:      "code-dir",
+					MountPath: "/code",
+				},
+			},
+		})
+		expectedPod.Spec.Containers[0].VolumeMounts = append(expectedPod.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
+			Name:      "code-dir",
+			MountPath: fmt.Sprintf("/home/envd/%s", projectName),
+		})
+		expectedPod.Spec.Volumes = append(expectedPod.Spec.Volumes, v1.Volume{
+			Name: "code-dir",
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{},
+				// HostPath: &v1.HostPathVolumeSource{
+				// 	Path: fmt.Sprintf("/var/envd/code/%s", req.Name),
+				// },
+			},
+		})
+	}
+
+	created, err := p.client.CoreV1().Pods(
+		p.namespace).Create(ctx, &expectedPod, metav1.CreateOptions{})
+	if err != nil {
+		logrus.Infof("failed to create pod: %v", err)
+		return nil, errors.Wrap(err, "failed to create pod")
+	}
+
+	expectedService := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      env.Name,
+			Namespace: p.namespace,
+			Labels:    labels,
+		},
+		Spec: v1.ServiceSpec{
+			Selector: labels,
+			Type:     v1.ServiceTypeClusterIP,
+			Ports: []v1.ServicePort{
+				{
+					Name: "ssh",
+					Port: 2222,
+				},
+			},
+		},
+	}
+	_, err = p.client.CoreV1().
+		Services(p.namespace).Create(ctx, &expectedService, metav1.CreateOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create service")
+	}
+
+	createdEnv, err := environmentFromKubernetesPod(created)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create environment")
+	}
+	return createdEnv, nil
+}

--- a/pkg/runtime/kubernetes/environment_get.go
+++ b/pkg/runtime/kubernetes/environment_get.go
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	"github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tensorchord/envd-server/api/types"
+	"github.com/tensorchord/envd-server/errdefs"
+	"github.com/tensorchord/envd-server/pkg/consts"
+)
+
+func (p generalProvisioner) EnvironmentGet(ctx context.Context,
+	owner, envName string) (*types.Environment, error) {
+
+	pod, err := p.client.CoreV1().
+		Pods(p.namespace).Get(ctx, envName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, errdefs.NotFound(err)
+		}
+		return nil, errors.Wrap(err, "failed to get pod")
+	}
+	if pod.Labels[consts.PodLabelUID] != owner {
+		logrus.WithFields(logrus.Fields{
+			"loginname_in_pod":     pod.Labels[consts.PodLabelUID],
+			"loginname_in_request": owner,
+		}).Debug("mismatch loginname")
+		return nil, errdefs.Unauthorized(errors.New("mismatch loginname"))
+	}
+
+	if pod == nil {
+		return nil, errdefs.NotFound(errors.New("pod not found"))
+	}
+
+	e, err := environmentFromKubernetesPod(pod)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to convert pod to environment")
+	}
+	return e, nil
+}

--- a/pkg/runtime/kubernetes/environment_list.go
+++ b/pkg/runtime/kubernetes/environment_list.go
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/tensorchord/envd-server/api/types"
+	"github.com/tensorchord/envd-server/errdefs"
+	"github.com/tensorchord/envd-server/pkg/consts"
+)
+
+func (p generalProvisioner) EnvironmentList(ctx context.Context,
+	owner string) ([]types.Environment, error) {
+	ls := labels.Set{
+		consts.PodLabelUID: owner,
+	}
+
+	pods, err := p.client.CoreV1().Pods(
+		p.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: ls.String(),
+	})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, errdefs.NotFound(err)
+		}
+		return nil, errors.Wrap(err, "failed to get pods")
+	}
+
+	res := []types.Environment{}
+
+	for _, pod := range pods.Items {
+		e, err := environmentFromKubernetesPod(&pod)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert pod to environment")
+		}
+		res = append(res, *e)
+	}
+
+	return res, nil
+}

--- a/pkg/runtime/kubernetes/environment_remove.go
+++ b/pkg/runtime/kubernetes/environment_remove.go
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tensorchord/envd-server/errdefs"
+	"github.com/tensorchord/envd-server/pkg/consts"
+)
+
+func (p generalProvisioner) EnvironmentRemove(ctx context.Context,
+	owner, envName string) error {
+	logger := logrus.WithField("env", envName)
+	pod, err := p.client.CoreV1().Pods(p.namespace).
+		Get(ctx, envName, metav1.GetOptions{})
+	if !k8serrors.IsNotFound(err) {
+		if err != nil {
+			return errors.Wrap(err, "failed to get pod")
+		}
+		if pod.Labels[consts.PodLabelUID] != owner {
+			logger.WithFields(logrus.Fields{
+				"loginname_in_pod":     pod.Labels[consts.PodLabelUID],
+				"loginname_in_request": owner,
+			}).Debug("mismatch loginname")
+			return errdefs.Unauthorized(errors.New("mismatch loginname"))
+		}
+
+		err = p.client.CoreV1().Pods(
+			p.namespace).Delete(ctx, envName, metav1.DeleteOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return errors.Wrap(err, "failed to delete pod")
+		}
+		logger.Debugf("pod %s is deleted", envName)
+	}
+
+	service, err := p.client.CoreV1().Services(p.namespace).
+		Get(ctx, envName, metav1.GetOptions{})
+	if !k8serrors.IsNotFound(err) {
+		if err != nil {
+			return errors.Wrap(err, "failed to get service")
+		}
+		if service.Labels[consts.PodLabelUID] != owner {
+			logger.WithFields(logrus.Fields{
+				"loginname_in_pod":     pod.Labels[consts.PodLabelUID],
+				"loginname_in_request": owner,
+			}).Debug("mismatch loginname")
+			return errdefs.Unauthorized(errors.New("mismatch loginname"))
+		}
+		err = p.client.CoreV1().Services(p.namespace).
+			Delete(ctx, envName, metav1.DeleteOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return errors.Wrap(err, "failed to delete service")
+		}
+		logger.Debugf("service %s is deleted", envName)
+	}
+
+	return nil
+}

--- a/pkg/runtime/kubernetes/kubernetes.go
+++ b/pkg/runtime/kubernetes/kubernetes.go
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package kubernetes
+
+import (
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/tensorchord/envd-server/pkg/runtime"
+)
+
+type generalProvisioner struct {
+	client kubernetes.Interface
+
+	namespace string
+}
+
+func NewProvisioner(client kubernetes.Interface) runtime.Provisioner {
+	return &generalProvisioner{
+		client:    client,
+		namespace: "default",
+	}
+}

--- a/pkg/runtime/kubernetes/util.go
+++ b/pkg/runtime/kubernetes/util.go
@@ -1,0 +1,104 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package kubernetes
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/tensorchord/envd-server/api/types"
+	"github.com/tensorchord/envd-server/pkg/consts"
+	"github.com/tensorchord/envd-server/pkg/util"
+	"github.com/tensorchord/envd-server/pkg/util/imageutil"
+)
+
+func extractResourceRequest(env types.Environment) (v1.ResourceList, error) {
+	res := env.Resources
+	resRequest := v1.ResourceList{}
+	if res.CPU != "" {
+		cpu, err := resource.ParseQuantity(res.CPU)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse cpu resource")
+		}
+		resRequest[v1.ResourceCPU] = cpu
+	}
+	if res.Memory != "" {
+		mem, err := resource.ParseQuantity(res.Memory)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse memory resource")
+		}
+		resRequest[v1.ResourceMemory] = mem
+	}
+	if res.GPU != "" {
+		gpu, err := resource.ParseQuantity(res.GPU)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse gpu resource")
+		}
+		resRequest["nvidia/gpu"] = gpu
+	}
+	return resRequest, nil
+}
+
+func environmentFromKubernetesPod(pod *v1.Pod) (*types.Environment, error) {
+	// Validate if the pod is an environment pod
+	if pod == nil {
+		return nil, errors.New("pod is nil")
+	}
+
+	env := &types.Environment{
+		ObjectMeta: types.ObjectMeta{
+			Name: pod.Name,
+		},
+		Spec:   types.EnvironmentSpec{},
+		Status: types.EnvironmentStatus{},
+	}
+
+	// Convert the spec.
+	if len(pod.Spec.Containers) != 0 {
+		env.Spec.Image = pod.Spec.Containers[0].Image
+		env.Spec.Env = envVarsfromKubernetes(pod.Spec.Containers[0].Env)
+		env.Spec.Cmd = pod.Spec.Containers[0].Command
+	}
+	if pod.Labels[consts.PodLabelUID] == "" {
+		env.Spec.Owner = pod.Labels[consts.PodLabelUID]
+	}
+	// Get the ports
+	portLabel, ok := pod.Annotations[consts.ImageLabelPorts]
+	if !ok {
+		logrus.Info("failed to get port label")
+		return nil, errors.New("failed to get port annotation")
+	}
+	ports, err := imageutil.PortsFromLabel(portLabel)
+	if err != nil {
+		logrus.Infof("failed to get ports from: %s", portLabel)
+		return nil, errors.Wrap(err, "failed to get ports from label")
+	}
+	env.Spec.Ports = ports
+
+	if jupyterAddr, ok := pod.Annotations[consts.PodLabelJupyterAddr]; ok {
+		env.Status.JupyterAddr = &jupyterAddr
+	}
+	if rstudioServerAddr, ok := pod.Annotations[consts.PodLabelRStudioServerAddr]; ok {
+		env.Status.RStudioServerAddr = &rstudioServerAddr
+	}
+
+	// only reserve labels with prefix `ai.tensorchord.envd.`
+	env.Labels = util.Filter(env.Labels, util.IsEnvdLabel)
+	env.Status.Phase = string(pod.Status.Phase)
+	return env, nil
+}
+
+func envVarsfromKubernetes(env []v1.EnvVar) []types.EnvVar {
+	envVars := make([]types.EnvVar, len(env))
+	for i, e := range env {
+		envVars[i] = types.EnvVar{
+			Name:  e.Name,
+			Value: e.Value,
+		}
+	}
+	return envVars
+}

--- a/pkg/runtime/kubernetes/util.go
+++ b/pkg/runtime/kubernetes/util.go
@@ -38,7 +38,7 @@ func extractResourceRequest(env types.Environment) (v1.ResourceList, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to parse gpu resource")
 		}
-		resRequest["nvidia/gpu"] = gpu
+		resRequest[ResourceNvidiaGPU] = gpu
 	}
 	return resRequest, nil
 }
@@ -63,7 +63,7 @@ func environmentFromKubernetesPod(pod *v1.Pod) (*types.Environment, error) {
 		env.Spec.Env = envVarsfromKubernetes(pod.Spec.Containers[0].Env)
 		env.Spec.Cmd = pod.Spec.Containers[0].Command
 	}
-	if pod.Labels[consts.PodLabelUID] == "" {
+	if pod.Labels[consts.PodLabelUID] != "" {
 		env.Spec.Owner = pod.Labels[consts.PodLabelUID]
 	}
 	// Get the ports

--- a/pkg/runtime/provisioner.go
+++ b/pkg/runtime/provisioner.go
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package runtime
+
+import (
+	"context"
+
+	"github.com/tensorchord/envd-server/api/types"
+	servertypes "github.com/tensorchord/envd-server/api/types"
+)
+
+type Provisioner interface {
+	EnvironmentCreate(ctx context.Context,
+		owner string, env servertypes.Environment,
+		meta types.ImageMeta) (*types.Environment, error)
+	EnvironmentGet(ctx context.Context,
+		owner, envName string) (*types.Environment, error)
+	EnvironmentRemove(ctx context.Context,
+		owner, envName string) error
+	EnvironmentList(ctx context.Context,
+		username string) ([]types.Environment, error)
+}

--- a/pkg/server/environment_list.go
+++ b/pkg/server/environment_list.go
@@ -5,17 +5,13 @@
 package server
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/tensorchord/envd-server/api/types"
-	"github.com/tensorchord/envd-server/pkg/consts"
-	"github.com/tensorchord/envd-server/pkg/util"
-	"github.com/tensorchord/envd-server/pkg/util/imageutil"
+	"github.com/tensorchord/envd-server/errdefs"
 )
 
 // @Summary     List the environment.
@@ -28,72 +24,22 @@ import (
 // @Success     200            {object} types.EnvironmentListResponse
 // @Router      /users/{login_name}/environments [get]
 func (s *Server) environmentList(c *gin.Context) {
-	it := c.GetString(ContextLoginName)
-	logger := logrus.WithField(ContextLoginName, it)
+	owner := c.GetString(ContextLoginName)
+	logger := logrus.WithField(ContextLoginName, owner)
 
-	ls := labels.Set{
-		consts.PodLabelUID: it,
-	}
-
-	pods, err := s.Client.CoreV1().Pods(
-		"default").List(c, metav1.ListOptions{
-		LabelSelector: ls.String(),
-	})
+	items, err := s.Runtime.EnvironmentList(c.Request.Context(), owner)
 	if err != nil {
-		logger.Error("failed to get pods: ", err)
-		if k8serrors.IsNotFound(err) {
-			c.JSON(404, types.EnvironmentListResponse{})
+		if errdefs.IsNotFound(err) {
+			c.JSON(http.StatusNotFound, err)
 			return
 		}
-		c.JSON(500, err)
-		return
 	}
 
 	res := types.EnvironmentListResponse{
-		Items: []types.Environment{},
+		Items: items,
 	}
 
-	for _, p := range pods.Items {
-		e, err := generateEnvironmentFromPod(p)
-		if err != nil {
-			logger.Error("failed to generate environment from pod: ", err)
-			c.JSON(500, err)
-			return
-		}
-		res.Items = append(res.Items, e)
-	}
 	logger.WithField("count", len(res.Items)).
 		Debug("list the environments successfully")
 	c.JSON(200, res)
-}
-
-// nolint:unparam
-func generateEnvironmentFromPod(p v1.Pod) (types.Environment, error) {
-	e := types.Environment{
-		ObjectMeta: types.ObjectMeta{
-			Labels: p.Annotations,
-			Name:   p.Name,
-		},
-		Spec: types.EnvironmentSpec{},
-	}
-	if len(p.Spec.Containers) != 0 {
-		e.Spec.Image = p.Spec.Containers[0].Image
-	}
-
-	if jupyterAddr, ok := p.Annotations[consts.PodLabelJupyterAddr]; ok {
-		e.Status.JupyterAddr = &jupyterAddr
-	}
-	if rstudioServerAddr, ok := p.Annotations[consts.PodLabelRStudioServerAddr]; ok {
-		e.Status.RStudioServerAddr = &rstudioServerAddr
-	}
-
-	ports, err := imageutil.PortsFromLabel(p.Annotations[consts.ImageLabelPorts])
-	if err != nil {
-		return e, err
-	}
-	e.Spec.Ports = ports
-	// only reserve labels with prefix `ai.tensorchord.envd.`
-	e.Labels = util.Filter(e.Labels, util.IsEnvdLabel)
-	e.Status.Phase = string(p.Status.Phase)
-	return e, nil
 }

--- a/pkg/server/environment_remove.go
+++ b/pkg/server/environment_remove.go
@@ -8,12 +8,9 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/sirupsen/logrus"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/tensorchord/envd-server/api/types"
-	"github.com/tensorchord/envd-server/pkg/consts"
 )
 
 // @Summary     Remove the environment.
@@ -27,7 +24,7 @@ import (
 // @Success     200            {object} types.EnvironmentRemoveResponse
 // @Router      /users/{login_name}/environments/{name} [delete]
 func (s *Server) environmentRemove(c *gin.Context) {
-	it := c.GetString(ContextLoginName)
+	owner := c.GetString(ContextLoginName)
 
 	var req types.EnvironmentRemoveRequest
 	if err := c.BindUri(&req); err != nil {
@@ -35,57 +32,16 @@ func (s *Server) environmentRemove(c *gin.Context) {
 		return
 	}
 
-	logger := logrus.WithFields(logrus.Fields{
-		"name":           req.Name,
-		ContextLoginName: it,
-	})
-	pod, err := s.Client.CoreV1().Pods("default").Get(c, req.Name, metav1.GetOptions{})
-	if !k8serrors.IsNotFound(err) {
-		if err != nil {
-			logger.Error(err)
-			c.JSON(500, err)
+	if err := s.Runtime.EnvironmentRemove(c.Request.Context(), owner, req.Name); err != nil {
+		if k8serrors.IsNotFound(err) {
+			c.JSON(http.StatusNotFound, err)
+			return
+		} else if k8serrors.IsUnauthorized(err) {
+			c.JSON(http.StatusUnauthorized, err)
 			return
 		}
-		if pod.Labels[consts.PodLabelUID] != it {
-			logger.WithFields(logrus.Fields{
-				"loginname_in_pod":     pod.Labels[consts.PodLabelUID],
-				"loginname_in_request": it,
-			}).Debug("mismatch loginname")
-			respondWithError(c, http.StatusUnauthorized, "unauthorized")
-			return
-		}
-		err = s.Client.CoreV1().Pods(
-			"default").Delete(c, req.Name, metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
-			logger.Error(err)
-			c.JSON(500, err)
-			return
-		}
-		logger.Debugf("pod %s is deleted", req.Name)
-	}
-
-	service, err := s.Client.CoreV1().Services("default").Get(c, req.Name, metav1.GetOptions{})
-	if !k8serrors.IsNotFound(err) {
-		if err != nil {
-			logger.Error(err)
-			c.JSON(500, err)
-			return
-		}
-		if service.Labels[consts.PodLabelUID] != it {
-			logger.WithFields(logrus.Fields{
-				"loginname_in_pod":     pod.Labels[consts.PodLabelUID],
-				"loginname_in_request": it,
-			}).Debug("mismatch loginname")
-			respondWithError(c, http.StatusUnauthorized, "unauthorized")
-			return
-		}
-		err = s.Client.CoreV1().Services("default").Delete(c, req.Name, metav1.DeleteOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
-			logger.Error(err)
-			c.JSON(500, err)
-			return
-		}
-		logger.Debugf("service %s is deleted", req.Name)
+		c.JSON(http.StatusInternalServerError, err)
+		return
 	}
 
 	c.JSON(200, types.EnvironmentRemoveResponse{})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -24,6 +24,8 @@ import (
 
 	_ "github.com/tensorchord/envd-server/pkg/docs"
 	"github.com/tensorchord/envd-server/pkg/query"
+	"github.com/tensorchord/envd-server/pkg/runtime"
+	runtimek8s "github.com/tensorchord/envd-server/pkg/runtime/kubernetes"
 	"github.com/tensorchord/envd-server/pkg/util"
 	"github.com/tensorchord/envd-server/pkg/web"
 )
@@ -32,7 +34,7 @@ type Server struct {
 	Router      *gin.Engine
 	AdminRouter *gin.Engine
 	Queries     *query.Queries
-	Client      kubernetes.Interface
+	Runtime     runtime.Provisioner
 
 	serverFingerPrints []string
 
@@ -96,9 +98,9 @@ func New(opt Opt) (*Server, error) {
 	s := &Server{
 		Router:             router,
 		AdminRouter:        admin,
-		Client:             cli,
 		Queries:            queries,
 		serverFingerPrints: make([]string, 0),
+		Runtime:            runtimek8s.NewProvisioner(cli),
 	}
 
 	// Load host key.

--- a/pkg/service/user/jwt.go
+++ b/pkg/service/user/jwt.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	jwt "github.com/golang-jwt/jwt/v4"
-	"github.com/pkg/errors"
 )
 
 // Create a struct that will be encoded to a JWT.

--- a/test/environments/list_test.go
+++ b/test/environments/list_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/google/uuid"
 
@@ -36,9 +35,6 @@ var _ = Describe("environments", Ordered, func() {
 			Expect(err).Should(BeNil())
 		}()
 		It("should get the newly created environments", func() {
-			l, err := srv.Client.CoreV1().Pods("default").List(context.TODO(), v1.ListOptions{})
-			Expect(err).Should(BeNil())
-			logger.Debug(l)
 			resp, err := cli.EnvironmentList(context.TODO())
 			Expect(err).Should(BeNil())
 			Expect(len(resp.Items)).Should(Equal(1))

--- a/test/util/server.go
+++ b/test/util/server.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kubernetes "k8s.io/client-go/kubernetes/fake"
 
+	runtimek8s "github.com/tensorchord/envd-server/pkg/runtime/kubernetes"
 	"github.com/tensorchord/envd-server/pkg/server"
 )
 
@@ -27,7 +28,7 @@ func NewServer(objects ...runtime.Object) (*server.Server, error) {
 	s := &server.Server{
 		Router:      router,
 		AdminRouter: admin,
-		Client:      cli,
+		Runtime:     runtimek8s.NewProvisioner(cli),
 		Auth:        false,
 	}
 


### PR DESCRIPTION
This PR is to abstract the access to Kubernetes, and make it a runtime interface, instead of using it directly

In the future, we may support remote machine as a new runtime.

Signed-off-by: Ce Gao <cegao@tensorchord.ai>