### PR TITLE
fix: exit when middleware auth fail

### DIFF
--- a/client/environment_remove.go
+++ b/client/environment_remove.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// EnvironmentList lists the environment.
+// EnvironmentRemove the environment.
 func (cli *Client) EnvironmentRemove(ctx context.Context,
 	name string) error {
 	username, headers, err := cli.getUserAndHeaders()

--- a/manifests/templates/NOTES.txt
+++ b/manifests/templates/NOTES.txt
@@ -18,6 +18,6 @@
   Please run these commands:
   kubectl --namespace {{ .Release.Namespace }} port-forward svc/envd-server 8080:8080 2222:2222
 
-  To get the pod name:  
+  To get the pod name:
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "envd-server.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
 {{- end }}

--- a/manifests/templates/postgres.yaml
+++ b/manifests/templates/postgres.yaml
@@ -85,5 +85,5 @@ spec:
   resources:
     requests:
       storage: 5Gi
---- 
+---
 {{- end -}}

--- a/pkg/server/auth_middleware.go
+++ b/pkg/server/auth_middleware.go
@@ -17,7 +17,6 @@ func (s *Server) AuthMiddleware() gin.HandlerFunc {
 		amURI := AuthMiddlewareURIRequest{}
 		if err := c.BindUri(&amURI); err != nil {
 			respondWithError(c, NewError(http.StatusUnauthorized, err, "auth.middleware.bind-uri"))
-			c.Next()
 			return
 		}
 
@@ -28,14 +27,12 @@ func (s *Server) AuthMiddleware() gin.HandlerFunc {
 		amr := AuthMiddlewareHeaderRequest{}
 		if err := c.BindHeader(&amr); err != nil {
 			respondWithError(c, NewError(http.StatusUnauthorized, err, "auth.middleware"))
-			c.Next()
 			return
 		}
 
 		loginName, err := s.UserService.ValidateJWT(amr.JWTToken)
 		if err != nil {
 			respondWithError(c, NewError(http.StatusUnauthorized, err, "user.validateJWT"))
-			c.Next()
 			return
 		}
 		if loginName != amURI.LoginName {
@@ -44,7 +41,6 @@ func (s *Server) AuthMiddleware() gin.HandlerFunc {
 				"login-name-in-uri": amURI.LoginName,
 			}).Debug("login name in JWT does not match the login name in URI")
 			respondWithError(c, NewError(http.StatusUnauthorized, err, "user.validateJWT"))
-			c.Next()
 			return
 		}
 		c.Set(ContextLoginName, loginName)
@@ -58,7 +54,6 @@ func (s *Server) NoAuthMiddleware() gin.HandlerFunc {
 		amURI := AuthMiddlewareURIRequest{}
 		if err := c.BindUri(&amURI); err != nil {
 			respondWithError(c, NewError(http.StatusUnauthorized, err, "auth.middleware.bind-uri"))
-			c.Next()
 			return
 		}
 


### PR DESCRIPTION
Signed-off-by: Keming <kemingyang@tensorchord.ai>

No need to run the `c.Next()` because `c.Set(ContextLoginName, amURI.LoginName)` is not reachable. The following process will always fail.